### PR TITLE
Add caching of STS-exchanged access tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,9 +491,12 @@ the corresponding `creds/:name` path.
 #### `GET` (`read`)
 
 Retrieve a new access token by performing a token exchange request on demand.
-The token exchange operation always sends the access token from the
+The token exchange operation sends the access token from the
 corresponding credential as the subject token and explicitly requests a new
 access token from the authorization server.
+Reuses previous token that was made with the same parameters
+if the provider specified an expiration time
+and the token is not yet expired or close to it.
 
 Parameters:
 
@@ -502,6 +505,7 @@ Parameters:
 | `scopes` | A list of explicit scopes to request. | List of String | None | No |
 | `audiences` | A list of explicit audiences to request. | List of String | None | No |
 | `resources` | A list of explicit resources to request. | List of String | None | No |
+| `minimum_seconds` | Minimum additional duration to require the access token to be valid for. | Integer | 10<sup id="ret-3-b">[3](#footnote-3)</sup> | No |
 
 ## Providers
 

--- a/pkg/backend/path_creds.go
+++ b/pkg/backend/path_creds.go
@@ -71,7 +71,7 @@ func (b *backend) credsReadOperation(ctx context.Context, req *logical.Request, 
 		}
 
 		return logical.ErrorResponse("token pending issuance"), nil
-	case !b.tokenValid(entry.Token, expiryDelta):
+	case !b.tokenValid(entry.Token.Token, expiryDelta):
 		if entry.AuthServerError != "" {
 			return logical.ErrorResponse("server %q has configuration problems: %s", entry.AuthServerName, entry.AuthServerError), nil
 		} else if entry.UserError != "" {

--- a/pkg/backend/path_self.go
+++ b/pkg/backend/path_self.go
@@ -32,7 +32,7 @@ func (b *backend) selfReadOperation(ctx context.Context, req *logical.Request, d
 		return nil, err
 	case entry == nil:
 		return nil, nil
-	case !b.tokenValid(entry.Token, expiryDelta):
+	case !b.tokenValid(entry.Token.Token, expiryDelta):
 		return logical.ErrorResponse("token expired"), nil
 	}
 

--- a/pkg/backend/token.go
+++ b/pkg/backend/token.go
@@ -4,14 +4,14 @@ import (
 	"time"
 
 	"github.com/puppetlabs/leg/timeutil/pkg/clock"
-	"github.com/puppetlabs/vault-plugin-secrets-oauthapp/v3/pkg/provider"
+	"golang.org/x/oauth2"
 )
 
 const (
 	defaultExpiryDelta = 10 * time.Second
 )
 
-func tokenExpired(clk clock.Clock, t *provider.Token, expiryDelta time.Duration) bool {
+func tokenExpired(clk clock.Clock, t *oauth2.Token, expiryDelta time.Duration) bool {
 	if t.Expiry.IsZero() {
 		return false
 	}
@@ -23,6 +23,6 @@ func tokenExpired(clk clock.Clock, t *provider.Token, expiryDelta time.Duration)
 	return t.Expiry.Round(0).Add(-expiryDelta).Before(clk.Now())
 }
 
-func (b *backend) tokenValid(tok *provider.Token, expiryDelta time.Duration) bool {
+func (b *backend) tokenValid(tok *oauth2.Token, expiryDelta time.Duration) bool {
 	return tok != nil && tok.AccessToken != "" && !tokenExpired(b.clock, tok, expiryDelta)
 }

--- a/pkg/backend/token_clientcreds.go
+++ b/pkg/backend/token_clientcreds.go
@@ -25,7 +25,7 @@ func (b *backend) updateClientCredsToken(ctx context.Context, storage logical.St
 		switch {
 		case err != nil || candidate == nil:
 			return err
-		case b.tokenValid(candidate.Token, expiryDelta):
+		case b.tokenValid(candidate.Token.Token, expiryDelta):
 			entry = candidate
 			return nil
 		}
@@ -66,7 +66,7 @@ func (b *backend) getUpdateClientCredsToken(ctx context.Context, storage logical
 	switch {
 	case err != nil:
 		return nil, err
-	case entry != nil && b.tokenValid(entry.Token, expiryDelta):
+	case entry != nil && b.tokenValid(entry.Token.Token, expiryDelta):
 		return entry, nil
 	default:
 		return b.updateClientCredsToken(ctx, storage, keyer, expiryDelta)

--- a/pkg/persistence/authcode.go
+++ b/pkg/persistence/authcode.go
@@ -15,6 +15,7 @@ import (
 	"github.com/puppetlabs/leg/timeutil/pkg/clockctx"
 	"github.com/puppetlabs/vault-plugin-secrets-oauthapp/v3/pkg/provider"
 	"github.com/puppetlabs/vault-plugin-secrets-oauthapp/v3/pkg/vaultext"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -68,6 +69,9 @@ type AuthCodeEntry struct {
 	// If the most recent exchange did not succeed, this holds the time that
 	// exchange occurred.
 	LastAttemptedIssueTime time.Time `json:"last_attempted_issue_time,omitempty"`
+
+	// Cache of successfully exchanged tokens
+	ExchangedTokens map[string]*oauth2.Token `json:"exchanged_tokens"`
 }
 
 func (ace *AuthCodeEntry) SetToken(ctx context.Context, tok *provider.Token) {


### PR DESCRIPTION
Import of puppetlabs/vault-plugin-secrets-oauthapp#90 which had the following description:

> Similar to the caching on the "creds" API, this adds caching on the "sts" API. It adds a minimum_seconds parameter.


