### PR TITLE
Move to common backend setup

### DIFF
--- a/pkg/backend/path_authcodeurl_test.go
+++ b/pkg/backend/path_authcodeurl_test.go
@@ -21,11 +21,7 @@ func TestAuthCodeURL(t *testing.T) {
 	pr := provider.NewRegistry()
 	pr.MustRegister("mock", testutil.MockFactory())
 
-	storage := &logical.InmemStorage{}
-
-	b, err := backend.New(backend.Options{ProviderRegistry: pr})
-	require.NoError(t, err)
-	require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
+	b, storage := backend.CreateBackendWithStorage(t, backend.Options{ProviderRegistry: pr})
 
 	// Write server configuration.
 	req := &logical.Request{

--- a/pkg/backend/path_config_test.go
+++ b/pkg/backend/path_config_test.go
@@ -20,11 +20,7 @@ func TestConfigReadWrite(t *testing.T) {
 	pr := provider.NewRegistry()
 	pr.MustRegister("mock", testutil.MockFactory(testutil.MockWithVersion(2)))
 
-	storage := &logical.InmemStorage{}
-
-	b, err := backend.New(backend.Options{ProviderRegistry: pr})
-	require.NoError(t, err)
-	require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
+	b, storage := backend.CreateBackendWithStorage(t, backend.Options{ProviderRegistry: pr})
 
 	// Read configuration; we should be unconfigured at this point.
 	read := &logical.Request{

--- a/pkg/backend/path_creds_test.go
+++ b/pkg/backend/path_creds_test.go
@@ -37,11 +37,7 @@ func TestBasicAuthCodeExchange(t *testing.T) {
 	pr := provider.NewRegistry()
 	pr.MustRegister("mock", testutil.MockFactory(testutil.MockWithAuthCodeExchange(client, testutil.StaticMockAuthCodeExchange(token))))
 
-	storage := &logical.InmemStorage{}
-
-	b, err := backend.New(backend.Options{ProviderRegistry: pr})
-	require.NoError(t, err)
-	require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
+	b, storage := backend.CreateBackendWithStorage(t, backend.Options{ProviderRegistry: pr})
 
 	// Write server configuration.
 	req := &logical.Request{
@@ -110,11 +106,7 @@ func TestClientSecretsFallback(t *testing.T) {
 	pr := provider.NewRegistry()
 	pr.MustRegister("mock", testutil.MockFactory(testutil.MockWithAuthCodeExchange(client, testutil.StaticMockAuthCodeExchange(token))))
 
-	storage := &logical.InmemStorage{}
-
-	b, err := backend.New(backend.Options{ProviderRegistry: pr})
-	require.NoError(t, err)
-	require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
+	b, storage := backend.CreateBackendWithStorage(t, backend.Options{ProviderRegistry: pr})
 
 	// Write server configuration.
 	req := &logical.Request{
@@ -167,11 +159,7 @@ func TestInvalidAuthCodeExchange(t *testing.T) {
 	pr := provider.NewRegistry()
 	pr.MustRegister("mock", testutil.MockFactory(testutil.MockWithAuthCodeExchange(client, exchange)))
 
-	storage := &logical.InmemStorage{}
-
-	b, err := backend.New(backend.Options{ProviderRegistry: pr})
-	require.NoError(t, err)
-	require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
+	b, storage := backend.CreateBackendWithStorage(t, backend.Options{ProviderRegistry: pr})
 
 	// Write server configuration.
 	req := &logical.Request{
@@ -245,11 +233,7 @@ func TestRefreshableAuthCodeExchange(t *testing.T) {
 	pr := provider.NewRegistry()
 	pr.MustRegister("mock", testutil.MockFactory(testutil.MockWithAuthCodeExchange(client, handler)))
 
-	storage := &logical.InmemStorage{}
-
-	b, err := backend.New(backend.Options{ProviderRegistry: pr})
-	require.NoError(t, err)
-	require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
+	b, storage := backend.CreateBackendWithStorage(t, backend.Options{ProviderRegistry: pr})
 
 	// Write server configuration.
 	req := &logical.Request{
@@ -332,11 +316,7 @@ func TestRefreshFailureReturnsNotConfigured(t *testing.T) {
 	pr := provider.NewRegistry()
 	pr.MustRegister("mock", testutil.MockFactory(testutil.MockWithAuthCodeExchange(client, exchange)))
 
-	storage := &logical.InmemStorage{}
-
-	b, err := backend.New(backend.Options{ProviderRegistry: pr})
-	require.NoError(t, err)
-	require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
+	b, storage := backend.CreateBackendWithStorage(t, backend.Options{ProviderRegistry: pr})
 
 	// Write server configuration.
 	req := &logical.Request{
@@ -421,26 +401,22 @@ func TestDeviceCodeAuthAndExchange(t *testing.T) {
 		testutil.MockWithDeviceCodeExchange(client, exchange),
 	))
 
-	storage := &logical.InmemStorage{}
-
 	clk := testclock.NewFakeClock(time.Now())
 
-	b, err := backend.New(backend.Options{
-		ProviderRegistry: pr,
-		Clock: clock.NewTimerCallbackClock(
-			k8sext.NewClock(clk),
-			func(d time.Duration) {
-				// Stepping the clock every time a timer is created or reset
-				// guarantees that the normally-delayed timer will immediately
-				// retry over and over.
-				clk.Step(d)
-			},
-		),
-	})
-	require.NoError(t, err)
-	require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
-	require.NoError(t, b.Initialize(ctx, &logical.InitializationRequest{Storage: storage}))
-	defer b.Cleanup(ctx)
+	b, storage := backend.CreateBackendWithStorage(t,
+		backend.Options{
+			ProviderRegistry: pr,
+			Clock: clock.NewTimerCallbackClock(
+				k8sext.NewClock(clk),
+				func(d time.Duration) {
+					// Stepping the clock every time a timer is created or reset
+					// guarantees that the normally-delayed timer will immediately
+					// retry over and over.
+					clk.Step(d)
+				},
+			),
+		},
+	)
 
 	// Write server configuration.
 	req := &logical.Request{
@@ -584,14 +560,12 @@ func TestAuthCodeMaximumExpiry(t *testing.T) {
 			pr := provider.NewRegistry()
 			pr.MustRegister("mock", testutil.MockFactory(testutil.MockWithAuthCodeExchange(client, test.ExchangeFunc)))
 
-			storage := &logical.InmemStorage{}
-
-			b, err := backend.New(backend.Options{
-				ProviderRegistry: pr,
-				Clock:            k8sext.NewClock(clk),
-			})
-			require.NoError(t, err)
-			require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
+			b, storage := backend.CreateBackendWithStorage(t,
+				backend.Options{
+					ProviderRegistry: pr,
+					Clock:            k8sext.NewClock(clk),
+				},
+			)
 
 			// Write server configuration.
 			req := &logical.Request{

--- a/pkg/backend/path_self_test.go
+++ b/pkg/backend/path_self_test.go
@@ -37,11 +37,7 @@ func TestClientCredentials(t *testing.T) {
 	pr := provider.NewRegistry()
 	pr.MustRegister("mock", testutil.MockFactory(testutil.MockWithClientCredentials(client, handler)))
 
-	storage := &logical.InmemStorage{}
-
-	b, err := backend.New(backend.Options{ProviderRegistry: pr})
-	require.NoError(t, err)
-	require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
+	b, storage := backend.CreateBackendWithStorage(t, backend.Options{ProviderRegistry: pr})
 
 	// Write server configuration.
 	req := &logical.Request{
@@ -122,11 +118,7 @@ func TestExpiredClientCredentials(t *testing.T) {
 	pr := provider.NewRegistry()
 	pr.MustRegister("mock", testutil.MockFactory(testutil.MockWithClientCredentials(client, handler)))
 
-	storage := &logical.InmemStorage{}
-
-	b, err := backend.New(backend.Options{ProviderRegistry: pr})
-	require.NoError(t, err)
-	require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
+	b, storage := backend.CreateBackendWithStorage(t, backend.Options{ProviderRegistry: pr})
 
 	// Write server configuration.
 	req := &logical.Request{
@@ -243,14 +235,12 @@ func TestClientCredentialsMaximumExpiry(t *testing.T) {
 			pr := provider.NewRegistry()
 			pr.MustRegister("mock", testutil.MockFactory(testutil.MockWithClientCredentials(client, test.ExchangeFunc)))
 
-			storage := &logical.InmemStorage{}
-
-			b, err := backend.New(backend.Options{
-				ProviderRegistry: pr,
-				Clock:            k8sext.NewClock(clk),
-			})
-			require.NoError(t, err)
-			require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
+			b, storage := backend.CreateBackendWithStorage(t,
+				backend.Options{
+					ProviderRegistry: pr,
+					Clock:            k8sext.NewClock(clk),
+				},
+			)
 
 			// Write server configuration.
 			req := &logical.Request{
@@ -333,11 +323,7 @@ func TestListCredentials(t *testing.T) {
 	pr := provider.NewRegistry()
 	pr.MustRegister("mock", testutil.MockFactory(testutil.MockWithClientCredentials(client, handler)))
 
-	storage := &logical.InmemStorage{}
-
-	b, err := backend.New(backend.Options{ProviderRegistry: pr})
-	require.NoError(t, err)
-	require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
+	b, storage := backend.CreateBackendWithStorage(t, backend.Options{ProviderRegistry: pr})
 
 	// Write server configuration.
 	req := &logical.Request{

--- a/pkg/backend/path_servers_test.go
+++ b/pkg/backend/path_servers_test.go
@@ -20,11 +20,7 @@ func TestServerReadWrite(t *testing.T) {
 	pr := provider.NewRegistry()
 	pr.MustRegister("mock", testutil.MockFactory(testutil.MockWithVersion(2)))
 
-	storage := &logical.InmemStorage{}
-
-	b, err := backend.New(backend.Options{ProviderRegistry: pr})
-	require.NoError(t, err)
-	require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
+	b, storage := backend.CreateBackendWithStorage(t, backend.Options{ProviderRegistry: pr})
 
 	// Read configuration; we should be unconfigured at this point.
 	read := &logical.Request{
@@ -115,11 +111,7 @@ func TestMultipleServers(t *testing.T) {
 	pr := provider.NewRegistry()
 	pr.MustRegister("mock", testutil.MockFactory(opts...))
 
-	storage := &logical.InmemStorage{}
-
-	b, err := backend.New(backend.Options{ProviderRegistry: pr})
-	require.NoError(t, err)
-	require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
+	b, storage := backend.CreateBackendWithStorage(t, backend.Options{ProviderRegistry: pr})
 
 	// Write server configurations and credentials.
 	for _, server := range servers {

--- a/pkg/backend/path_sts_test.go
+++ b/pkg/backend/path_sts_test.go
@@ -41,11 +41,7 @@ func TestLimitedExchange(t *testing.T) {
 		})),
 	))
 
-	storage := &logical.InmemStorage{}
-
-	b, err := backend.New(backend.Options{ProviderRegistry: pr})
-	require.NoError(t, err)
-	require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
+	b, storage := backend.CreateBackendWithStorage(t, backend.Options{ProviderRegistry: pr})
 
 	// Write server configuration.
 	req := &logical.Request{

--- a/pkg/backend/path_test.go
+++ b/pkg/backend/path_test.go
@@ -27,11 +27,7 @@ func TestAcceptableCredentialNames(t *testing.T) {
 		testutil.MockWithClientCredentials(client, testutil.RandomMockClientCredentials),
 	))
 
-	storage := &logical.InmemStorage{}
-
-	b, err := backend.New(backend.Options{ProviderRegistry: pr})
-	require.NoError(t, err)
-	require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
+	b, storage := backend.CreateBackendWithStorage(t, backend.Options{ProviderRegistry: pr})
 
 	// Write server configuration.
 	req := &logical.Request{

--- a/pkg/backend/testing.go
+++ b/pkg/backend/testing.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2025 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package backend
+
+import (
+	"testing"
+
+	"github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stretchr/testify/require"
+)
+
+func CreateBackendWithStorage(t *testing.T, opts Options) (*backend, logical.Storage) {
+	t.Helper()
+
+	config := logical.TestBackendConfig()
+	config.StorageView = &logical.InmemStorage{}
+
+	b, err := New(opts)
+	require.NoError(t, err, "failed to create backend")
+
+	err = b.Setup(t.Context(), config)
+	require.NoError(t, err, "failed to setup backend")
+
+	err = b.Initialize(t.Context(), &logical.InitializationRequest{
+		Storage: config.StorageView,
+	})
+	require.NoError(t, err, "unable to initialize backend")
+
+	t.Cleanup(func() {
+		b.Cleanup(t.Context())
+	})
+
+	return b.(*backend), config.StorageView
+}

--- a/pkg/backend/token_authcode_reap_test.go
+++ b/pkg/backend/token_authcode_reap_test.go
@@ -36,24 +36,20 @@ func TestPeriodicReap(t *testing.T) {
 	pr := provider.NewRegistry()
 	pr.MustRegister("mock", testutil.MockFactory(testutil.MockWithAuthCodeExchange(client, exchange)))
 
-	storage := &logical.InmemStorage{}
-
-	b, err := backend.New(backend.Options{
-		ProviderRegistry: pr,
-		Clock: clock.NewTimerCallbackClock(
-			k8sext.NewClock(clk),
-			func(d time.Duration) {
-				// Stepping the clock every time a timer is created or reset
-				// guarantees that the normally-delayed timer will immediately
-				// retry over and over.
-				clk.Step(d)
-			},
-		),
-	})
-	require.NoError(t, err)
-	require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
-	require.NoError(t, b.Initialize(ctx, &logical.InitializationRequest{Storage: storage}))
-	defer b.Cleanup(ctx)
+	b, storage := backend.CreateBackendWithStorage(t,
+		backend.Options{
+			ProviderRegistry: pr,
+			Clock: clock.NewTimerCallbackClock(
+				k8sext.NewClock(clk),
+				func(d time.Duration) {
+					// Stepping the clock every time a timer is created or reset
+					// guarantees that the normally-delayed timer will immediately
+					// retry over and over.
+					clk.Step(d)
+				},
+			),
+		},
+	)
 
 	// Write configuration.
 	req := &logical.Request{

--- a/pkg/backend/token_authcode_test.go
+++ b/pkg/backend/token_authcode_test.go
@@ -64,24 +64,20 @@ func TestPeriodicRefresh(t *testing.T) {
 	pr := provider.NewRegistry()
 	pr.MustRegister("mock", testutil.MockFactory(testutil.MockWithAuthCodeExchange(client, testutil.RestrictMockAuthCodeExchange(exchanges))))
 
-	storage := &logical.InmemStorage{}
-
-	b, err := backend.New(backend.Options{
-		ProviderRegistry: pr,
-		Clock: clock.NewTimerCallbackClock(
-			k8sext.NewClock(clk),
-			func(d time.Duration) {
-				// Stepping the clock every time a timer is created or reset
-				// guarantees that the normally-delayed timer will immediately
-				// retry over and over.
-				clk.Step(d)
-			},
-		),
-	})
-	require.NoError(t, err)
-	require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
-	require.NoError(t, b.Initialize(ctx, &logical.InitializationRequest{Storage: storage}))
-	defer b.Cleanup(ctx)
+	b, storage := backend.CreateBackendWithStorage(t,
+		backend.Options{
+			ProviderRegistry: pr,
+			Clock: clock.NewTimerCallbackClock(
+				k8sext.NewClock(clk),
+				func(d time.Duration) {
+					// Stepping the clock every time a timer is created or reset
+					// guarantees that the normally-delayed timer will immediately
+					// retry over and over.
+					clk.Step(d)
+				},
+			),
+		},
+	)
 
 	// Write server configuration.
 	req := &logical.Request{
@@ -171,13 +167,7 @@ func TestTuneRefreshCheckInterval(t *testing.T) {
 	pr := provider.NewRegistry()
 	pr.MustRegister("mock", testutil.MockFactory(testutil.MockWithAuthCodeExchange(client, exchange)))
 
-	storage := &logical.InmemStorage{}
-
-	b, err := backend.New(backend.Options{ProviderRegistry: pr})
-	require.NoError(t, err)
-	require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
-	require.NoError(t, b.Initialize(ctx, &logical.InitializationRequest{Storage: storage}))
-	defer b.Cleanup(ctx)
+	b, storage := backend.CreateBackendWithStorage(t, backend.Options{ProviderRegistry: pr})
 
 	// Write server configuration.
 	req := &logical.Request{
@@ -334,14 +324,7 @@ func TestMinimumSeconds(t *testing.T) {
 			testutil.RestrictMockTokenExchange(tokenExchanges)),
 	))
 
-	storage := &logical.InmemStorage{}
-
-	b, err := backend.New(backend.Options{
-		ProviderRegistry: pr,
-	})
-	require.NoError(t, err)
-	require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
-	defer b.Cleanup(ctx)
+	b, storage := backend.CreateBackendWithStorage(t, backend.Options{ProviderRegistry: pr})
 
 	// Write server configuration.
 	req := &logical.Request{
@@ -511,16 +494,12 @@ func TestServerDeletedFromUnderCred(t *testing.T) {
 		testutil.MockWithAuthCodeExchange(client2, expire(testutil.IncrementMockAuthCodeExchange("client2_"))),
 	))
 
-	storage := &logical.InmemStorage{}
-
-	b, err := backend.New(backend.Options{
-		ProviderRegistry: pr,
-		Clock:            k8sext.NewClock(clk),
-	})
-	require.NoError(t, err)
-	require.NoError(t, b.Setup(ctx, &logical.BackendConfig{StorageView: storage}))
-	require.NoError(t, b.Initialize(ctx, &logical.InitializationRequest{Storage: storage}))
-	defer b.Cleanup(ctx)
+	b, storage := backend.CreateBackendWithStorage(t,
+		backend.Options{
+			ProviderRegistry: pr,
+			Clock:            k8sext.NewClock(clk),
+		},
+	)
 
 	// Write global configuratio to turn off the reaper for creds without
 	// servers, which could fire since we're rapidly incrementing the clock.


### PR DESCRIPTION
This uses logical.TestBackendConfig(...) so that we always have a working logical.SystemView implementation and fixes the consistency of Setup/Initialize/Cleanup calls across the codebase.

---

@DrDaveD You can see something similar at https://github.com/openbao/openbao/blob/9d92cd8d02bb6c8ddae0d318432ba891e1b7541b/internal/builtin/logical/pki/test_helpers.go#L29-L45, though without some of the extra consistency I've added here. 